### PR TITLE
set shift key to "none" if you want to only use the default key 1 on an iii arc as shift

### DIFF
--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -88,7 +88,7 @@ mod.hook.register("script_pre_init", "arcwise_script_pre_init", function()
       type = "option",
       id = "arcwise_shift_key",
       name = "shift key",
-      options = { "K1", "K2", "K3" },
+      options = { "K1", "K2", "K3", "none" },
       default = 1,
     })
     params:add({


### PR DESCRIPTION
Using a iii capable arc, the button is already set as a shift key. If so, using a button on norns to do the same may be redundant - added "none" as an option to the "arcwise_shift_key" param.